### PR TITLE
Remove `build.dev` in favour of `process.env.NODE_ENV` in the Cloudflare Workers template.

### DIFF
--- a/templates/cloudflare-workers/server.ts
+++ b/templates/cloudflare-workers/server.ts
@@ -7,7 +7,7 @@ import __STATIC_CONTENT_MANIFEST from "__STATIC_CONTENT_MANIFEST";
 const MANIFEST = JSON.parse(__STATIC_CONTENT_MANIFEST);
 const handleRemixRequest = createRequestHandler(build, process.env.NODE_ENV);
 
-if (build.dev) {
+if (process.env.NODE_ENV === "development") {
   logDevReady(build);
 }
 


### PR DESCRIPTION
Fixes #6891 (discussed there)

This change removes the deprecated `build.dev` from the `cloudflare-workers` template, which was the only template that still used it, and replaces it with  `process.env.NODE_ENV`.

This is arguably better than the previous solution as Remix uses an ESBuild `define` to replace `process.env.NODE_ENV` at compile-time, which means the whole code path will be tree-shaken out of production bundles. For the same reason, it’s better than using Cloudflare-specific methods for checking for the environment.